### PR TITLE
Prevent browsers from caching schema responses

### DIFF
--- a/src/RequestHandler/VerificationHandlerTrait.php
+++ b/src/RequestHandler/VerificationHandlerTrait.php
@@ -74,6 +74,10 @@ trait VerificationHandlerTrait
         $token = SecurityToken::inst();
         $token->reset();
         $data[$token->getName()] = $token->getValue();
+        
+        // prevent caching of response
+        $response->addHeader('Pragma', 'no-cache');
+        $response->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');              
 
         // Respond with our method
         return $response->setBody(json_encode($data));


### PR DESCRIPTION
Should fix time out messages described here:
https://github.com/silverstripe/silverstripe-mfa/issues/414